### PR TITLE
Made the wrapper's Dispose methods virtual

### DIFF
--- a/src/Pomade/Pomade.cs
+++ b/src/Pomade/Pomade.cs
@@ -70,7 +70,7 @@
         public virtual async Task<AsyncGridReader> QueryMultipleAsync(string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) => new AsyncGridReader(await _dbConnection.QueryMultipleAsync(sql, param, transaction, commandTimeout, commandType));
         public virtual async Task<AsyncGridReader> QueryMultipleAsync(CommandDefinition command) => new AsyncGridReader(await _dbConnection.QueryMultipleAsync(command));
 
-        public void Dispose() => _dbConnection?.Dispose();
+        public virtual void Dispose() => _dbConnection?.Dispose();
 
         public class AsyncGridReader : IDisposable
         {
@@ -102,7 +102,7 @@
             public virtual Task<T> ReadSingleAsync<T>() => _gridReader.ReadSingleAsync<T>();
             public virtual Task<T> ReadSingleOrDefaultAsync<T>() => _gridReader.ReadSingleOrDefaultAsync<T>();
 
-            public void Dispose() => _gridReader?.Dispose();
+            public virtual void Dispose() => _gridReader?.Dispose();
         }
     }
 }

--- a/src/Pomade/Pomade.csproj
+++ b/src/Pomade/Pomade.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="1.50.2" />
+    <PackageReference Include="Dapper" Version="1.60.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
 So that dispose logic can be tested if it is more complex than a trivial `using` block. 

Also updated Dapper dependency to 1.60.6